### PR TITLE
Implement symmetric storage encryption with AES-GCM

### DIFF
--- a/.travis-script.sh
+++ b/.travis-script.sh
@@ -7,11 +7,19 @@ export BUILD_UI=1
 # build keyfender container
 docker/build-all-in-one.sh
 
-docker network create -d bridge --subnet 10.99.99.0/24 --gateway 10.99.99.1 dockernet
-docker run -i --rm --net dockernet --ip 10.99.99.3 --name irmin -v $OPAM_DIR:/home/opam/.opam keyfender_buildbase irmin init -a http://0.0.0.0:8081 -d --verbosity=info -s mem 2>&1 | sed "s/^/<irmin> /" &
+docker network create -d bridge --subnet 10.99.99.0/24 --gateway 10.99.99.1 \
+  dockernet
+
+docker run -i --rm --net dockernet --ip 10.99.99.3 --name irmin \
+  -v $OPAM_DIR:/home/opam/.opam keyfender_buildbase irmin init \
+  -a http://0.0.0.0:8081 -d --verbosity=info -s mem 2>&1 \
+  | sed "s/^/<irmin> /" &
 
 # run keyfender on port 4433
-docker run -i --rm -p4433:4433 --device=/dev/net/tun:/dev/net/tun --cap-add=NET_ADMIN --net dockernet --ip 10.99.99.2 keyfender/keyfender --irmin http://10.99.99.3:8081 2>&1 | sed "s/^/<keyfender> /" &
+docker run -i --rm -p4433:4433 --device=/dev/net/tun:/dev/net/tun \
+  --cap-add=NET_ADMIN --net dockernet --ip 10.99.99.2 keyfender/keyfender \
+  --masterkey 000102030405060708090A0B0C0D0E0F --irmin http://10.99.99.3:8081 \
+  2>&1 | sed "s/^/<keyfender> /" &
 
 # functional tests
 cd tests/end-to-end/

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,12 +10,15 @@ cache:
     - $HOME/.sbt
     - $HOME/.ivy2
     - $HOME/.apk-cache
+branches:
+  only:
+  - master
 before_cache:
   - rm -rfv $HOME/.opam/log ;
     if [ "$TRAVIS_TEST_RESULT" = "0" -a "$TRAVIS_BRANCH" = "master" ]; then
     LAST_UI_SHA=$( cat $HOME/.apk-cache/.last_ui_sha );
     UI_SHA=$( curl -s -H "Accept:application/vnd.github.v3.sha" https://api.github.com/repos/keyfender/keyfender-ui/commits/master );
-    if [ "$TRAVIS_EVENT_TYPE" != "cron" -o "$UI_SHA" != "$LAST_UI_SHA" ]; then
+    if [ "$TRAVIS_EVENT_TYPE" = "push" -o "$UI_SHA" != "$LAST_UI_SHA" ]; then
     echo -n $UI_SHA > $HOME/.apk-cache/.last_ui_sha ;
     docker login -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD";
     export REPO=keyfender/keyfender;

--- a/docker/container-scripts/start.sh
+++ b/docker/container-scripts/start.sh
@@ -8,6 +8,7 @@ echo "##### Keyfender container setup #####"
 [ -n "$KEYFENDER_HTTPS_PORT" ] && ARGS="$ARGS --https=$KEYFENDER_HTTPS_PORT"
 [ -n "$KEYFENDER_PASSWORD" ] && ARGS="$ARGS --password=$KEYFENDER_PASSWORD"
 [ -n "$KEYFENDER_IRMIN_URL" ] && ARGS="$ARGS --irmin-url=$KEYFENDER_IRMIN_URL"
+[ -n "$KEYFENDER_MASTERKEY" ] && ARGS="$ARGS --masterkey=$KEYFENDER_MASTERKEY"
 
 NS=${KEYFENDER_NS:-$(grep ^nameserver /etc/resolv.conf | head -1 | awk '{print $2}')}
 echo "Nameserver: $NS"

--- a/src/api.ml
+++ b/src/api.ml
@@ -59,7 +59,7 @@ module Config = struct
     with Not_found -> None
 end
 
-module Dispatch (H:Cohttp_lwt.S.Server)(KR:Keyring.S)(Clock:Webmachine.CLOCK) = struct
+module Dispatch (H:Cohttp_lwt.S.Server)(KR:S.Keyring)(Clock:Webmachine.CLOCK) = struct
   let jsend_success data =
     let l = match data with
       | `Null -> []

--- a/src/api.mli
+++ b/src/api.mli
@@ -1,4 +1,4 @@
-module Dispatch (H:Cohttp_lwt.S.Server)(KR:Keyring.S)(Clock:Webmachine.CLOCK) : sig
+module Dispatch (H:Cohttp_lwt.S.Server)(KR:S.Keyring)(Clock:Webmachine.CLOCK) : sig
   val dispatcher : KR.storage -> Cohttp.Request.t -> Cohttp_lwt.Body.t
     -> (Cohttp.Response.t * Cohttp_lwt.Body.t) Lwt.t
 end

--- a/src/config.ml
+++ b/src/config.ml
@@ -32,6 +32,12 @@ let nameserver =
   Key.abstract Key.(create "nameserver"
     Arg.(opt ~stage:`Both string "8.8.8.8" doc))
 
+let masterkey =
+  let doc = Key.Arg.info ~doc:"Masterkey for AES storage encryption \
+    (16, 24 or 32 byte hexcode)." ["masterkey"] in
+  Key.abstract Key.(create "masterkey"
+    Arg.(opt ~stage:`Both string "" doc))
+
 let main =
   let packages = [
     package "cohttp-mirage";
@@ -43,7 +49,8 @@ let main =
     package "irmin-http";
     package "ppx_sexp_conv";
   ] in
-  let keys = [ http_port; https_port; admin_password; irmin_url; nameserver ] in
+  let keys = [ http_port; https_port; admin_password; irmin_url; nameserver;
+    masterkey ] in
   foreign
     ~packages ~keys
     "Hsm.Main" (pclock @-> kv_ro @-> kv_ro @-> stackv4 @-> conduit

--- a/src/contents.ml
+++ b/src/contents.ml
@@ -1,16 +1,36 @@
-module Sexp(
-  T : S.Sexp
-) : Irmin.Contents.S with type t = T.t =
+
+module Raw (T : sig type t end) =
 struct
   type t = T.t
   let to_raw (x:t) = Marshal.to_string x []
   let of_raw x : t = Marshal.from_string x 0
   let t = Irmin.Type.(like string) of_raw to_raw
   let merge = Irmin.Merge.idempotent (Irmin.Type.option t)
+end
+
+module Sexp
+  (T : S.SexpConvertable)
+: Irmin.Contents.S with type t = T.t =
+struct
+  include Raw(T)
   let of_string s =
     Ok (T.t_of_sexp @@ Sexplib.Sexp.of_string s)
   let to_string x =
     Sexplib.Sexp.to_string @@ T.sexp_of_t x
+  let pp ppf x =
+    Fmt.pf ppf "%s" (to_string x)
+end
+
+module EncryptedSexp
+  (T : S.SexpConvertable)
+  (E : S.Encryptor)
+: Irmin.Contents.S with type t = T.t =
+struct
+  include Raw(T)
+  let of_string s =
+    Ok (E.decrypt s |> Sexplib.Sexp.of_string |> T.t_of_sexp)
+  let to_string x =
+    T.sexp_of_t x |> Sexplib.Sexp.to_string |> E.encrypt
   let pp ppf x =
     Fmt.pf ppf "%s" (to_string x)
 end

--- a/src/contents.mli
+++ b/src/contents.mli
@@ -1,3 +1,8 @@
-module Sexp(
-  T : S.Sexp
-) : Irmin.Contents.S with type t = T.t
+module Sexp
+  ( T : S.SexpConvertable )
+  : Irmin.Contents.S with type t = T.t
+
+module EncryptedSexp
+  ( T : S.SexpConvertable )
+  ( E : S.Encryptor)
+  : Irmin.Contents.S with type t = T.t

--- a/src/encryptor.ml
+++ b/src/encryptor.ml
@@ -1,0 +1,31 @@
+module GCM = Nocrypto.Cipher_block.AES.GCM
+module Rng = Nocrypto.Rng
+
+type encData = {
+  iv: Cstruct.t;
+  data: Cstruct.t;
+} [@@deriving sexp]
+
+module Make
+  (K : S.EncKey)
+  : S.Encryptor =
+struct
+  let key = GCM.of_secret K.key
+
+  let decrypt s =
+    let { iv ; data } = (Sexplib.Sexp.of_string s |> encData_of_sexp) in
+    let res = GCM.decrypt ~key ~iv data in
+    let plain = res.GCM.message in
+    Cstruct.to_string plain
+
+  let encrypt s =
+    let iv = Rng.generate 12 in
+    let res = GCM.encrypt ~key ~iv (Cstruct.of_string s) in
+    let data = res.GCM.message in
+    sexp_of_encData { iv; data } |> Sexplib.Sexp.to_string
+end
+
+module Null : S.Encryptor = struct
+  let encrypt s = s
+  let decrypt s = s
+end

--- a/src/encryptor.mli
+++ b/src/encryptor.mli
@@ -1,0 +1,4 @@
+
+module Make (K : S.EncKey) : S.Encryptor
+
+module Null : S.Encryptor

--- a/src/keyring.ml
+++ b/src/keyring.ml
@@ -1,10 +1,9 @@
 open Lwt.Infix
 open Sexplib.Std
 
-module type S = S.Keyring
-
 module Make
     (KV: Irmin.KV_MAKER)
+    (Enc: S.Encryptor)
 = struct
 
 exception Failure_exn of Yojson.Basic.json
@@ -44,7 +43,7 @@ module Padding = struct
     | PSS of Nocrypto.Hash.hash
 end
 
-module Storage = KV(Contents.Sexp(Priv))
+module Storage = KV(Contents.EncryptedSexp(Priv)(Enc))
 type storage = Storage.t
 let info _ = Irmin.Info.none
 

--- a/src/keyring.mli
+++ b/src/keyring.mli
@@ -1,3 +1,1 @@
-module type S = S.Keyring
-
-module Make (KV: Irmin.KV_MAKER) : S
+module Make (KV: Irmin.KV_MAKER)(Enc: S.Encryptor) : S.Keyring

--- a/src/s.mli
+++ b/src/s.mli
@@ -1,7 +1,16 @@
-module type Sexp = sig
+module type SexpConvertable = sig
   type t
   val t_of_sexp : Sexplib.Sexp.t -> t
   val sexp_of_t : t -> Sexplib.Sexp.t
+end
+
+module type Encryptor = sig
+  val encrypt : string -> string
+  val decrypt : string -> string
+end
+
+module type EncKey = sig
+  val key : Cstruct.t
 end
 
 module type Keyring = sig


### PR DESCRIPTION
The values of the Irmin storage (that is, not the key IDs) are now
encrypted with AES in GCM mode.  The symmetric key is for now
provided with the --masterkey command line argument, which takes a
16, 24 or 32 byte key in hex format.  The container image start
script supports a KEYFENDER_MASTERKEY environment variable, that sets
this commandline accordingly.  If no masterkey is provided, the
storage is still in plaintext as before and a warning is printed.